### PR TITLE
Don't log concurrency recommendations

### DIFF
--- a/profile/nodejs.sh
+++ b/profile/nodejs.sh
@@ -31,7 +31,7 @@ export PATH="$HOME/.paasprovider/node/bin:$HOME/bin:$HOME/node_modules/.bin:$PAT
 export NODE_HOME="$HOME/.paasprovider/node"
 
 calculate_concurrency
-log_concurrency
+#log_concurrency
 
 export MEMORY_AVAILABLE=$MEMORY_AVAILABLE
 export WEB_MEMORY=$WEB_MEMORY

--- a/test/run
+++ b/test/run
@@ -369,40 +369,40 @@ testMultiExport() {
   assertCapturedSuccess
 }
 
-testConcurrency1X() {
-  MEMORY_AVAILABLE=512 capture $(pwd)/profile/nodejs.sh
-  assertCaptured "Detected 512 MB available memory, 512 MB limit per process (WEB_MEMORY)"
-  assertCaptured "Recommending WEB_CONCURRENCY=1"
-  assertCapturedSuccess
-}
+# testConcurrency1X() {
+#   MEMORY_AVAILABLE=512 capture $(pwd)/profile/nodejs.sh
+#   assertCaptured "Detected 512 MB available memory, 512 MB limit per process (WEB_MEMORY)"
+#   assertCaptured "Recommending WEB_CONCURRENCY=1"
+#   assertCapturedSuccess
+# }
 
-testConcurrency2X() {
-  MEMORY_AVAILABLE=1024 capture $(pwd)/profile/nodejs.sh
-  assertCaptured "Detected 1024 MB available memory, 512 MB limit per process (WEB_MEMORY)"
-  assertCaptured "Recommending WEB_CONCURRENCY=2"
-  assertCapturedSuccess
-}
+# testConcurrency2X() {
+#   MEMORY_AVAILABLE=1024 capture $(pwd)/profile/nodejs.sh
+#   assertCaptured "Detected 1024 MB available memory, 512 MB limit per process (WEB_MEMORY)"
+#   assertCaptured "Recommending WEB_CONCURRENCY=2"
+#   assertCapturedSuccess
+# }
 
-testConcurrencyPX() {
-  MEMORY_AVAILABLE=6144 capture $(pwd)/profile/nodejs.sh
-  assertCaptured "Detected 6144 MB available memory, 512 MB limit per process (WEB_MEMORY)"
-  assertCaptured "Recommending WEB_CONCURRENCY=12"
-  assertCapturedSuccess
-}
+# testConcurrencyPX() {
+#   MEMORY_AVAILABLE=6144 capture $(pwd)/profile/nodejs.sh
+#   assertCaptured "Detected 6144 MB available memory, 512 MB limit per process (WEB_MEMORY)"
+#   assertCaptured "Recommending WEB_CONCURRENCY=12"
+#   assertCapturedSuccess
+# }
 
-testConcurrencyCustomLimit() {
-  MEMORY_AVAILABLE=1024 WEB_MEMORY=256 capture $(pwd)/profile/nodejs.sh
-  assertCaptured "Detected 1024 MB available memory, 256 MB limit per process (WEB_MEMORY)"
-  assertCaptured "Recommending WEB_CONCURRENCY=4"
-  assertCapturedSuccess
-}
+# testConcurrencyCustomLimit() {
+#   MEMORY_AVAILABLE=1024 WEB_MEMORY=256 capture $(pwd)/profile/nodejs.sh
+#   assertCaptured "Detected 1024 MB available memory, 256 MB limit per process (WEB_MEMORY)"
+#   assertCaptured "Recommending WEB_CONCURRENCY=4"
+#   assertCapturedSuccess
+# }
 
-testConcurrencySaneMaximum() {
-  MEMORY_AVAILABLE=6144 WEB_MEMORY=32 capture $(pwd)/profile/nodejs.sh
-  assertCaptured "Detected 6144 MB available memory, 32 MB limit per process (WEB_MEMORY)"
-  assertCaptured "Recommending WEB_CONCURRENCY=32"
-  assertCapturedSuccess
-}
+# testConcurrencySaneMaximum() {
+#   MEMORY_AVAILABLE=6144 WEB_MEMORY=32 capture $(pwd)/profile/nodejs.sh
+#   assertCaptured "Detected 6144 MB available memory, 32 MB limit per process (WEB_MEMORY)"
+#   assertCaptured "Recommending WEB_CONCURRENCY=32"
+#   assertCapturedSuccess
+# }
 
 
 # Utils


### PR DESCRIPTION
The `calculate_concurrency` heuristic is written for Heroku's dynos and
can't be translated to our setup. Hence, stop logging the result to not
confuse users.